### PR TITLE
feat: improve modal and guide navigation UX

### DIFF
--- a/dist/guides/cpf-retirement-guide.html
+++ b/dist/guides/cpf-retirement-guide.html
@@ -57,6 +57,22 @@
             text-align: center;
             border-bottom: 1px solid #f1f1f1;
         }
+        
+        /* Navigation link styles matching Guide 1 */
+        .nav-link {
+            padding: 0.5rem 0.75rem;
+            margin: 0 0.125rem;
+            border-radius: 6px;
+            text-decoration: none;
+            color: #6b7280;
+            font-size: 0.75rem;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+        .nav-link:hover, .nav-link.active {
+            background-color: #ed2e38;
+            color: white;
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
@@ -64,20 +80,22 @@
     <nav id="guide-nav" class="fixed top-0 left-0 right-0 bg-white shadow-md z-50 border-b-2 border-red-100">
         <div class="max-w-6xl mx-auto px-4 py-3">
             <div class="flex items-center justify-between">
-                <a href="../index.html" class="flex items-center space-x-3 text-red-600 hover:text-red-800 transition-colors">
+              <div class="flex items-center space-x-4">
+                <a href="../index.html" class="flex items-center space-x-2 text-red-600 hover:text-red-800 transition-colors">
                     <i class="fas fa-arrow-left"></i>
                     <span class="font-semibold">메인으로</span>
                 </a>
-                <div class="hidden md:flex space-x-4 text-sm">
-                    <a href="#section-0" class="nav-link px-3 py-2 rounded-lg transition-colors">커버</a>
-                    <a href="#section-1" class="nav-link px-3 py-2 rounded-lg transition-colors">개요</a>
-                    <a href="#section-2" class="nav-link px-3 py-2 rounded-lg transition-colors">계좌변화</a>
-                    <a href="#section-3" class="nav-link px-3 py-2 rounded-lg transition-colors">FRS이해</a>
-                    <a href="#section-4" class="nav-link px-3 py-2 rounded-lg transition-colors">달성전략</a>
-                    <a href="#section-5" class="nav-link px-3 py-2 rounded-lg transition-colors">인출옵션</a>
-                    <a href="#section-6" class="nav-link px-3 py-2 rounded-lg transition-colors">SRS비교</a>
-                    <a href="#section-7" class="nav-link px-3 py-2 rounded-lg transition-colors">실행계획</a>
+                <div class="flex space-x-2 text-sm">
+                    <a href="#section-0" class="nav-link px-2 py-1 rounded transition-colors">커버</a>
+                    <a href="#section-1" class="nav-link px-2 py-1 rounded transition-colors">개요</a>
+                    <a href="#section-2" class="nav-link px-2 py-1 rounded transition-colors">계좌변화</a>
+                    <a href="#section-3" class="nav-link px-2 py-1 rounded transition-colors">FRS이해</a>
+                    <a href="#section-4" class="nav-link px-2 py-1 rounded transition-colors">달성전략</a>
+                    <a href="#section-5" class="nav-link px-2 py-1 rounded transition-colors">인출옵션</a>
+                    <a href="#section-6" class="nav-link px-2 py-1 rounded transition-colors">SRS비교</a>
+                    <a href="#section-7" class="nav-link px-2 py-1 rounded transition-colors">실행계획</a>
                 </div>
+              </div>
             </div>
         </div>
     </nav>

--- a/dist/index.html
+++ b/dist/index.html
@@ -178,10 +178,10 @@
       <nav class="guide-nav">
         <ul class="guide-nav-list">
           <li class="guide-nav-item">
-            <a href="#guide-stock-guide" class="guide-nav-link active" onclick="showGuide('stock-guide', this)">주식투자 원칙 가이드</a>
+            <a href="guides/stock-investment-guide.html" class="guide-nav-link active" onclick="trackGuideClick('stock-guide')">주식투자 원칙 가이드</a>
           </li>
           <li class="guide-nav-item">
-            <a href="#guide-cpf55-guide" class="guide-nav-link" onclick="showGuide('cpf55-guide', this)">55세 CPF 변화 가이드</a>
+            <a href="guides/cpf-retirement-guide.html" class="guide-nav-link" onclick="trackGuideClick('cpf55-guide')">55세 CPF 변화 가이드</a>
           </li>
         </ul>
       </nav>
@@ -539,6 +539,41 @@
         params: {
           guide_slug: slug,
           file_name: filename
+        }
+      };
+      sendTrackingData(payload);
+    }
+
+    // Guide tab click tracking
+    function trackGuideClick(guideId) {
+      const guide = GUIDES[guideId];
+      
+      // GA4 tracking
+      if (typeof gtag === 'function') {
+        gtag('event', 'guide_tab_click', {
+          guide_slug: guide.slug,
+          guide_title: guide.title,
+          engagement_time_msec: 1000
+        });
+      }
+
+      // Enhanced user journey tracking
+      trackUserScore('guide_tab_click', 15, {
+        guide_slug: guide.slug,
+        guide_title: guide.title,
+        click_source: 'modal_tab'
+      });
+
+      // Custom tracking
+      const payload = {
+        cid: getCidForTracking(),
+        page: location.href,
+        title: document.title,
+        event_name: 'guide_tab_click',
+        params: {
+          guide_slug: guide.slug,
+          guide_title: guide.title,
+          click_source: 'modal_tab'
         }
       };
       sendTrackingData(payload);

--- a/guides/cpf-retirement-guide.html
+++ b/guides/cpf-retirement-guide.html
@@ -57,6 +57,22 @@
             text-align: center;
             border-bottom: 1px solid #f1f1f1;
         }
+        
+        /* Navigation link styles matching Guide 1 */
+        .nav-link {
+            padding: 0.5rem 0.75rem;
+            margin: 0 0.125rem;
+            border-radius: 6px;
+            text-decoration: none;
+            color: #6b7280;
+            font-size: 0.75rem;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+        .nav-link:hover, .nav-link.active {
+            background-color: #ed2e38;
+            color: white;
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
@@ -64,20 +80,22 @@
     <nav id="guide-nav" class="fixed top-0 left-0 right-0 bg-white shadow-md z-50 border-b-2 border-red-100">
         <div class="max-w-6xl mx-auto px-4 py-3">
             <div class="flex items-center justify-between">
-                <a href="../index.html" class="flex items-center space-x-3 text-red-600 hover:text-red-800 transition-colors">
+              <div class="flex items-center space-x-4">
+                <a href="../index.html" class="flex items-center space-x-2 text-red-600 hover:text-red-800 transition-colors">
                     <i class="fas fa-arrow-left"></i>
                     <span class="font-semibold">메인으로</span>
                 </a>
-                <div class="hidden md:flex space-x-4 text-sm">
-                    <a href="#section-0" class="nav-link px-3 py-2 rounded-lg transition-colors">커버</a>
-                    <a href="#section-1" class="nav-link px-3 py-2 rounded-lg transition-colors">개요</a>
-                    <a href="#section-2" class="nav-link px-3 py-2 rounded-lg transition-colors">계좌변화</a>
-                    <a href="#section-3" class="nav-link px-3 py-2 rounded-lg transition-colors">FRS이해</a>
-                    <a href="#section-4" class="nav-link px-3 py-2 rounded-lg transition-colors">달성전략</a>
-                    <a href="#section-5" class="nav-link px-3 py-2 rounded-lg transition-colors">인출옵션</a>
-                    <a href="#section-6" class="nav-link px-3 py-2 rounded-lg transition-colors">SRS비교</a>
-                    <a href="#section-7" class="nav-link px-3 py-2 rounded-lg transition-colors">실행계획</a>
+                <div class="flex space-x-2 text-sm">
+                    <a href="#section-0" class="nav-link px-2 py-1 rounded transition-colors">커버</a>
+                    <a href="#section-1" class="nav-link px-2 py-1 rounded transition-colors">개요</a>
+                    <a href="#section-2" class="nav-link px-2 py-1 rounded transition-colors">계좌변화</a>
+                    <a href="#section-3" class="nav-link px-2 py-1 rounded transition-colors">FRS이해</a>
+                    <a href="#section-4" class="nav-link px-2 py-1 rounded transition-colors">달성전략</a>
+                    <a href="#section-5" class="nav-link px-2 py-1 rounded transition-colors">인출옵션</a>
+                    <a href="#section-6" class="nav-link px-2 py-1 rounded transition-colors">SRS비교</a>
+                    <a href="#section-7" class="nav-link px-2 py-1 rounded transition-colors">실행계획</a>
                 </div>
+              </div>
             </div>
         </div>
     </nav>

--- a/src/index.html
+++ b/src/index.html
@@ -178,10 +178,10 @@
       <nav class="guide-nav">
         <ul class="guide-nav-list">
           <li class="guide-nav-item">
-            <a href="#guide-stock-guide" class="guide-nav-link active" onclick="showGuide('stock-guide', this)">주식투자 원칙 가이드</a>
+            <a href="guides/stock-investment-guide.html" class="guide-nav-link active" onclick="trackGuideClick('stock-guide')">주식투자 원칙 가이드</a>
           </li>
           <li class="guide-nav-item">
-            <a href="#guide-cpf55-guide" class="guide-nav-link" onclick="showGuide('cpf55-guide', this)">55세 CPF 변화 가이드</a>
+            <a href="guides/cpf-retirement-guide.html" class="guide-nav-link" onclick="trackGuideClick('cpf55-guide')">55세 CPF 변화 가이드</a>
           </li>
         </ul>
       </nav>
@@ -539,6 +539,41 @@
         params: {
           guide_slug: slug,
           file_name: filename
+        }
+      };
+      sendTrackingData(payload);
+    }
+
+    // Guide tab click tracking
+    function trackGuideClick(guideId) {
+      const guide = GUIDES[guideId];
+      
+      // GA4 tracking
+      if (typeof gtag === 'function') {
+        gtag('event', 'guide_tab_click', {
+          guide_slug: guide.slug,
+          guide_title: guide.title,
+          engagement_time_msec: 1000
+        });
+      }
+
+      // Enhanced user journey tracking
+      trackUserScore('guide_tab_click', 15, {
+        guide_slug: guide.slug,
+        guide_title: guide.title,
+        click_source: 'modal_tab'
+      });
+
+      // Custom tracking
+      const payload = {
+        cid: getCidForTracking(),
+        page: location.href,
+        title: document.title,
+        event_name: 'guide_tab_click',
+        params: {
+          guide_slug: guide.slug,
+          guide_title: guide.title,
+          click_source: 'modal_tab'
         }
       };
       sendTrackingData(payload);


### PR DESCRIPTION
Modal Improvements:
- Changed tab clicks to direct navigation to guide pages
- Removed confusing '가이드 보기' button workflow
- Added trackGuideClick() function for enhanced analytics
- Users now click tab → go directly to guide (no intermediate step)

Guide 2 Navigation Enhancement:
- Added visible navigation tabs to CPF guide matching Guide 1 style
- Removed hidden md:flex that hid tabs on mobile devices
- Added consistent .nav-link styling with red hover states
- Now both guides have identical navigation UX

UX Problems Fixed:
- ❌ 'Tab click → no response → confusion'
- ✅ 'Tab click → direct guide navigation'
- ❌ 'Guide 2 missing visible tabs on mobile'
- ✅ 'Guide 2 has visible tabs on all screen sizes'

This eliminates user confusion and provides consistent navigation across all guides.